### PR TITLE
Fix: Remove artificial 500 error from contact form submission

### DIFF
--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,11 +1,13 @@
 export default function handler(req, res) {
-  const { name } = req.body;
-  if (typeof name === 'string' && name.toLowerCase().includes('error')) {
-    return res.status(500).json({ message: 'Error!' })
+  const { name, email, message } = req.body;
+  
+  // Basic validation
+  if (!name || !email) {
+    return res.status(400).json({ message: 'Name and email are required' });
   }
 
   // Pretend to do something with name, email, message
   // In a real scenario, you'd store them or send an email.
-  res.status(200).json({ message: 'Subscribed successfully!' })
+  res.status(200).json({ message: 'Subscribed successfully!' });
 }
 


### PR DESCRIPTION
## Summary
This PR fixes the contact form submission bug that was causing 500 errors.

## Problem
The subscribe API endpoint had an artificial error condition that returned a 500 error whenever the name field contained the word 'error'. This was causing legitimate contact form submissions to fail unnecessarily.

## Solution
- Removed the artificial error check that was looking for 'error' in the name field
- Replaced it with proper validation for required fields (name and email)
- Now returns 400 (Bad Request) for missing required fields instead of 500 (Internal Server Error)

## Testing
The fix ensures that:
- Valid submissions with any name (including those containing 'error') now succeed
- Missing required fields return appropriate 400 errors
- The contact form works as expected

## Related
Fixes the bug reported in Jam: https://jam.dev/c/889bdc44-5326-4700-8017-133913d33b09

## Changes
- Modified `pages/api/subscribe.js` to remove artificial error condition
- Added proper validation for required fields