### PR TITLE
Fix: Contact Form 500 Error When Name Contains 'Error'

### DIFF
--- a/__tests__/subscribe.test.js
+++ b/__tests__/subscribe.test.js
@@ -1,0 +1,69 @@
+/**
+ * Regression test for contact form submission bug
+ * 
+ * Bug: Contact form submission fails with 500 Internal Server Error 
+ * when submitting to /xhr/subscribe endpoint (actually /api/subscribe in Next.js)
+ * 
+ * Reproduction steps:
+ * 1. Submit contact form with the following data:
+ *    - Name: "Sam Errorful"
+ *    - Email: "chw93@e@virginia.edu"
+ *    - Message: "This is a test"
+ * 2. POST request to /api/subscribe endpoint returns 500 status code
+ * 3. Error message displayed: "An error occurred. Please try again."
+ * 
+ * This test MUST fail while the bug is present (expects 200 but gets 500)
+ */
+
+const { createMocks } = require('node-mocks-http');
+const handler = require('../pages/api/subscribe').default;
+
+describe('Contact Form Subscription API', () => {
+  test('should successfully handle contact form submission with name "Sam Errorful"', () => {
+    // Create mock request and response objects
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: {
+        name: 'Sam Errorful',
+        email: 'chw93@e@virginia.edu',
+        message: 'This is a test'
+      },
+    });
+
+    // Call the API handler
+    handler(req, res);
+
+    // This test expects a 200 status code (success)
+    // But the bug causes it to return 500 because the name contains "error"
+    expect(res._getStatusCode()).toBe(200);
+    
+    const jsonData = JSON.parse(res._getData());
+    expect(jsonData).toHaveProperty('message');
+    expect(jsonData.message).toBe('Subscribed successfully!');
+  });
+
+  test('should successfully handle normal contact form submission', () => {
+    // This test should pass - it's a control test
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: {
+        name: 'John Doe',
+        email: 'john@example.com',
+        message: 'Hello world'
+      },
+    });
+
+    handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    
+    const jsonData = JSON.parse(res._getData());
+    expect(jsonData.message).toBe('Subscribed successfully!');
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.js', '**/?(*.)+(spec|test).js'],
+  collectCoverageFrom: [
+    'pages/**/*.js',
+    'components/**/*.js',
+    '!pages/_app.js',
+    '!pages/_document.js',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -4,12 +4,21 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "next": "13.4.12",
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.28.4",
+    "@babel/preset-env": "^7.28.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "babel-jest": "^30.2.0",
+    "jest": "^30.2.0",
+    "node-mocks-http": "^1.17.2"
   }
 }
-

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,9 +1,4 @@
 export default function handler(req, res) {
-  const { name } = req.body;
-  if (typeof name === 'string' && name.toLowerCase().includes('error')) {
-    return res.status(500).json({ message: 'Error!' })
-  }
-
   // Pretend to do something with name, email, message
   // In a real scenario, you'd store them or send an email.
   res.status(200).json({ message: 'Subscribed successfully!' })


### PR DESCRIPTION
# Fix: Contact Form 500 Error When Name Contains "Error"

## 🐛 Bug Description

Contact form submissions were failing with a **500 Internal Server Error** when the name field contained the word "error" (case-insensitive). This prevented legitimate users with names like "Sam Errorful" from successfully subscribing.

### Reproduction Steps
1. Navigate to the contact form
2. Enter the following data:
   - **Name**: "Sam Errorful"
   - **Email**: "chw93@e@virginia.edu"
   - **Message**: "This is a test"
3. Submit the form
4. **Expected**: Success message
5. **Actual**: Error message "An error occurred. Please try again." (500 status)

## 🔍 Root Cause

The `/api/subscribe` endpoint contained an incorrect validation check that returned a 500 error if the name field contained the substring "error":

```javascript
// BUGGY CODE (removed)
const { name } = req.body;
if (typeof name === 'string' && name.toLowerCase().includes('error')) {
  return res.status(500).json({ message: 'Error!' })
}
```

This validation logic was incorrect and had no legitimate business purpose. It caused valid submissions to fail.

## ✅ Fix Applied

Removed the erroneous error condition from `pages/api/subscribe.js`. The API now correctly processes all valid form submissions regardless of the name content.

### Code Changes
```diff
 export default function handler(req, res) {
-  const { name } = req.body;
-  if (typeof name === 'string' && name.toLowerCase().includes('error')) {
-    return res.status(500).json({ message: 'Error!' })
-  }
-
   // Pretend to do something with name, email, message
   // In a real scenario, you'd store them or send an email.
   res.status(200).json({ message: 'Subscribed successfully!' })
 }
```

## 🧪 Testing

### Regression Test Added
Created comprehensive test suite in `__tests__/subscribe.test.js` to prevent this bug from reoccurring:

**Test Case 1**: Verifies that names containing "error" are processed successfully
- Input: `{ name: 'Sam Errorful', email: 'chw93@e@virginia.edu', message: 'This is a test' }`
- Expected: 200 status with success message
- **Status**: ✅ PASSING (was failing before fix)

**Test Case 2**: Control test for normal submissions
- Input: `{ name: 'John Doe', email: 'john@example.com', message: 'Hello world' }`
- Expected: 200 status with success message
- **Status**: ✅ PASSING

### Test Results
```
PASS __tests__/subscribe.test.js
  Contact Form Subscription API
    ✓ should successfully handle contact form submission with name "Sam Errorful" (6 ms)
    ✓ should successfully handle normal contact form submission

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

## 📦 Files Changed

- **`pages/api/subscribe.js`** - Removed incorrect error validation logic
- **`__tests__/subscribe.test.js`** - Added regression tests (NEW)
- **`package.json`** - Added Jest test dependencies and test script
- **`jest.config.js`** - Jest configuration (NEW)
- **`babel.config.js`** - Babel configuration for ES6 module support in tests (NEW)

## 🚀 Impact

- ✅ Users with names containing "error" can now successfully subscribe
- ✅ All form submissions are processed correctly
- ✅ Regression test suite prevents this bug from reoccurring
- ✅ No breaking changes to existing functionality

## 📝 Checklist

- [x] Bug fix implemented and tested
- [x] Regression tests added and passing
- [x] All existing tests still pass
- [x] Code follows project conventions
- [x] Commit message is descriptive
- [x] No breaking changes introduced
